### PR TITLE
Make work with GHC 9.0 and TemplateHaskell 2.17

### DIFF
--- a/shared-fields.cabal
+++ b/shared-fields.cabal
@@ -28,8 +28,8 @@ library
   exposed-modules:
     Control.Lens.TH.SharedFields
   build-depends:
-    base == 4.8.*,
-    template-haskell == 2.10.*
+    base == 4.15.*,
+    template-haskell == 2.17.*
   hs-source-dirs: src/
   default-language: Haskell2010
   default-extensions: TemplateHaskell

--- a/src/Control/Lens/TH/SharedFields.hs
+++ b/src/Control/Lens/TH/SharedFields.hs
@@ -21,7 +21,7 @@ make name =
   ClassD
     []
     (mkName $ "Has" ++ name)
-    [PlainTV s, PlainTV a]
+    [PlainTV s (), PlainTV a ()]
     [FunDep [s] [a]]
     [SigD (mkName $ functionName name) methodType]
   where
@@ -33,7 +33,7 @@ make name =
     vf = VarT f
     methodType =
       ForallT
-        [PlainTV f]
+        [PlainTV f SpecifiedSpec]
         [AppT (ConT ''Functor) vf]
         ((va `arrow` AppT vf va) `arrow` (vs `arrow` AppT vf vs))
 


### PR DESCRIPTION
PlainTV got additional flags in this release:  hehttps://gitlab.haskell.org/ghc/ghc/-/wikis/migration/9.0#template-haskell-217

I'm not sure about the cabal file version stuff, or if there should be some conditional compilation based on GHC version, but the library needs some fixes to work! These changes make it work in 9.0.1 for me.